### PR TITLE
Removed redundant filtering

### DIFF
--- a/src/propelleride/mainwindow.cpp
+++ b/src/propelleride/mainwindow.cpp
@@ -1111,9 +1111,7 @@ void MainWindow::enumeratePorts()
             cbPort->addItem(name);
 #else
         name = ports.at(i).physName;
-        if(name.indexOf("usb",0,Qt::CaseInsensitive) > -1 || name.indexOf("ama",0,Qt::CaseInsensitive) > -1) {
-            cbPort->addItem(name);
-        }
+        cbPort->addItem(name);
 #endif
     }
     if(!cbPort->count()) {

--- a/src/propelleride/mainwindow.cpp
+++ b/src/propelleride/mainwindow.cpp
@@ -1111,7 +1111,7 @@ void MainWindow::enumeratePorts()
             cbPort->addItem(name);
 #else
         name = ports.at(i).physName;
-        if(name.indexOf("usb",0,Qt::CaseInsensitive) > -1) {
+        if(name.indexOf("usb",0,Qt::CaseInsensitive) > -1 || name.indexOf("ama",0,Qt::CaseInsensitive) > -1) {
             cbPort->addItem(name);
         }
 #endif


### PR DESCRIPTION
Tested on Raspberry Pi, haven't given Windows/Mac the same treatment yet, as I can't verify they don't explode. But this filtering is handled upstream, so it *should* be safe. ( Famous last words! )